### PR TITLE
Add params in query and support for body part and find mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This plugin acts as a proxy bridge to integrate Craft CMS with [FileMaker](https
 
 ---
 
-## 🛠 Installation
+## Installation
 
 1. Require the package via Composer:
    ```bash
@@ -21,26 +21,26 @@ This plugin acts as a proxy bridge to integrate Craft CMS with [FileMaker](https
 
 ---
 
-## ⚙️ Plugin Settings
+## Plugin Settings
 
 Go to **Settings → FileMaker Proxy** in your Craft control panel to configure:
 
-### 🔐 Connection Credentials
+### Connection Credentials
 
 * Create your FileMaker connection credentials under the **Connections** tab.
 * These will include host, username, password, and database.
 
-### 📧 Admin Email
+### Admin Email
 
 * Enter an admin email to receive error reports for failed or unexpected requests.
 
-### 🔑 API Token
+### API Token
 
 * Define a secure **API token** that will be used to authorize incoming requests to the proxy endpoints.
 
 ---
 
-## 🧩 Profiles
+## Profiles
 
 To handle different integrations, you can create multiple **Profiles**:
 
@@ -56,9 +56,9 @@ To handle different integrations, you can create multiple **Profiles**:
 
 ---
 
-## 🚀 Usage with Craft Plugins
+## Usage with Craft Plugins
 
-### 1. **Webhooks Plugin**
+### 1. Webhooks Plugin
 
 * Make sure the profile **endpoint is enabled**.
 * Use the generated profile endpoint URL as the **Request URL** in the Webhooks plugin.
@@ -70,30 +70,44 @@ To handle different integrations, you can create multiple **Profiles**:
 
   Replace `TOKEN` with the API token you set in the plugin settings.
 
-### 2. **Feed Me Plugin**
+### 2. Feed Me Plugin
 
 * Set the profile as **enabled** (endpoint does not need to be enabled).
-* Add the profile’s endpoint URL as the **feed URL**.
+* Add the profile's endpoint URL as the **feed URL**.
 * When Feed Me initiates a request, it will automatically be intercepted and forwarded to FileMaker through the defined connection.
 
-### 3. **Formie Plugin**
+**Pagination:** You can append `_limit` and `_offset` directly to the feed URL to paginate through records:
+
+```
+http://localhost/actions/filemaker-proxy/api/middleware?profile=myProfile&_limit=100&_offset=0
+```
+
+**Find mode:** To use FileMaker's `_find` endpoint instead of `records`, add `mode=find` to the URL and include your query criteria in the request body:
+
+```
+http://localhost/actions/filemaker-proxy/api/middleware?profile=myProfile&mode=find
+```
+
+The default mode is `records`.
+
+### 3. Formie Plugin
 
 * Create a custom integration under the **Miscellaneous** type.
 * Select and configure the appropriate FileMaker profile within your form.
 
-### 4. **Freeform Plugin**
+### 4. Freeform Plugin
 
 * Create a custom integration under the **Other** type.
 * Configure it similarly to Formie by linking to a FileMaker profile.
 
-### 5. **Form Builder Plugin**
+### 5. Form Builder Plugin
 
 * Create a custom integration under the **Miscellaneous** type.
 * Configure the FileMaker settings within the form setup.
 
 ---
 
-## 🔒 Security Notes
+## Security Notes
 
 * Only requests from `localhost` can trigger real interactions with FileMaker.
 * All endpoints are protected using API tokens defined in your plugin settings.
@@ -101,9 +115,8 @@ To handle different integrations, you can create multiple **Profiles**:
 
 ---
 
-## 📬 Support
+## Support
 
 For issues or feature requests, please open an issue in the repository or contact the maintainer.
 
 ---
-

--- a/src/controllers/ApiController.php
+++ b/src/controllers/ApiController.php
@@ -55,9 +55,18 @@ class ApiController extends Controller
             throw new NotFoundHttpException('Page not found.');
         }
         $method = $this->request->getMethod();
+        $mode = $this->request->getQueryParam('mode', 'records');
+
         $data = $this->request->getBodyParams();
+
+        $queryParams = $this->request->getQueryParams();
+        unset($queryParams['profile'], $queryParams['mode']);
+        if (!empty($queryParams)) {
+            $data = array_merge($data, $queryParams);
+        }
+
         try {
-            $response = FmProxy::getInstance()->api->makeRequest($profile, $method, $data);
+            $response = FmProxy::getInstance()->api->makeRequest($profile, $method, $data, $mode);
             $result = $response->getBody()->getContents();
             return $this->asJson(json_decode($result, true));
         } catch (GuzzleException $e) {

--- a/src/models/Profile.php
+++ b/src/models/Profile.php
@@ -42,6 +42,14 @@ class Profile extends Model
         return "https://$host/fmi/data/vLatest/databases/$database/layouts/$this->layout/records";
     }
 
+    public function getFindUrl(): string
+    {
+        $connection = $this->getConnection();
+        $host = App::parseEnv($connection->host);
+        $database = App::parseEnv($connection->database);
+        return "https://$host/fmi/data/vLatest/databases/$database/layouts/$this->layout/_find";
+    }
+
     public function getConnection(): ?Connection
     {
         if(isset($this->_connection)) {

--- a/src/services/ApiService.php
+++ b/src/services/ApiService.php
@@ -103,7 +103,7 @@ class ApiService extends Component
      * @throws Exception
      * @throws GuzzleException
      */
-    public function makeRequest(Profile $profile, string $method = 'GET', array $data = []): ?\Psr\Http\Message\ResponseInterface
+    public function makeRequest(Profile $profile, string $method = 'GET', array $data = [], string $mode = 'records'): ?\Psr\Http\Message\ResponseInterface
     {
         $token = $this->authenticate($profile);
 
@@ -116,6 +116,13 @@ class ApiService extends Component
             'verify' => true,
         ]);
 
+        if ($mode === 'find') {
+            $url = $profile->getFindUrl();
+            $method = 'POST';
+        } else {
+            $url = $profile->getRecordUrl();
+        }
+
         $options = [
             'headers' => [
                 'Authorization' => 'Bearer ' . $token,
@@ -123,15 +130,21 @@ class ApiService extends Component
             ],
         ];
 
-        if (!empty($data)) {
-            $options['json'] = $data;
+        if ($method === 'GET') {
+            if (!empty($data)) {
+                $url .= '?' . http_build_query($data);
+            }
+        } else {
+            if (!empty($data)) {
+                $options['json'] = $data;
+            }
         }
 
         $maxRetries = 5;
-        
+
         for ($attempt = 1; $attempt <= $maxRetries; $attempt++) {
             try {
-                $response = $client->request($method, $profile->getRecordUrl(), $options);
+                $response = $client->request($method, $url, $options);
                 // Logout after successful request
                 $this->logout($profile, $token);
                 
@@ -179,7 +192,12 @@ class ApiService extends Component
                     if (!$profile) {
                         return null;
                     }
-                    $response =  FmProxy::getInstance()->api->makeRequest($profile, $method, $options);
+                    $mode = $queryParams['mode'] ?? 'records';
+                    unset($queryParams['profile'], $queryParams['mode']);
+
+                    $data = array_merge($queryParams, $options);
+
+                    $response = FmProxy::getInstance()->api->makeRequest($profile, $method, $data, $mode);
                     return $response->getBody()->getContents();
                 }
             }

--- a/src/services/ApiService.php
+++ b/src/services/ApiService.php
@@ -195,9 +195,7 @@ class ApiService extends Component
                     $mode = $queryParams['mode'] ?? 'records';
                     unset($queryParams['profile'], $queryParams['mode']);
 
-                    $data = array_merge($queryParams, $options);
-
-                    $response = FmProxy::getInstance()->api->makeRequest($profile, $method, $data, $mode);
+                    $response = FmProxy::getInstance()->api->makeRequest($profile, $method, $queryParams, $mode);
                     return $response->getBody()->getContents();
                 }
             }


### PR DESCRIPTION
- Add mode param and fix query param forwarding for FileMaker middleware
- Add `mode` query param (default: records, option: find) to select the FileMaker endpoint (_find vs records) per request
- Add Profile::getFindUrl() returning the _find layout endpoint
- Fix makeRequest() to send data as URL query params for GET requests and as JSON body for POST/PUT/DELETE, instead of always using JSON
- handleRequestedUrl() now extracts mode, strips reserved params (profile, mode), and merges remaining query params into data
- ApiController merges non-reserved query params into data so callers can pass _limit, _offset etc. directly in the Feed Me URL

Write operations (Formie/Freeform/Form Builder) are unaffected as they call makeRequest() directly with POST and a body.