### PR TITLE
Add Feed Me pagination support via nextUrl injection

### DIFF
--- a/src/FmProxy.php
+++ b/src/FmProxy.php
@@ -181,7 +181,7 @@ class FmProxy extends Plugin
             function(\craft\feedme\events\FeedDataEvent  $event) {
                 $url = $event->url;
                 $options = \craft\feedme\Plugin::$plugin->service->getRequestOptions($event->feedId);
-                $response = FmProxy::getInstance()->api->handleRequestedUrl($url, 'GET', $options);
+                $response = FmProxy::getInstance()->api->handleFeedMeRequest($url, 'GET', $options);
                 if ($response) {
                     $event->response = ['success' => true, 'data' => $response];;
                 }

--- a/src/services/ApiService.php
+++ b/src/services/ApiService.php
@@ -204,6 +204,37 @@ class ApiService extends Component
         return null;
     }
     
+    public function handleFeedMeRequest(string $url, string $method, array $options): ?string
+    {
+        $body = $this->handleRequestedUrl($url, $method, $options);
+        if (!$body) {
+            return null;
+        }
+
+        $data = json_decode($body, true);
+        $dataInfo = $data['response']['dataInfo'] ?? null;
+
+        if ($dataInfo && isset($dataInfo['foundCount'], $dataInfo['returnedCount'])) {
+            $parsed = parse_url($url);
+            parse_str($parsed['query'] ?? '', $queryParams);
+
+            $offset     = (int)($queryParams['_offset'] ?? 0);
+            $nextOffset = $offset + (int)$dataInfo['returnedCount'];
+
+            if ($nextOffset < (int)$dataInfo['foundCount']) {
+                $queryParams['_offset'] = $nextOffset;
+                $nextUrl = $parsed['scheme'] . '://' . $parsed['host']
+                    . ($parsed['path'] ?? '')
+                    . '?' . http_build_query($queryParams);
+
+                $data['response']['dataInfo']['nextUrl'] = $nextUrl;
+                return json_encode($data);
+            }
+        }
+
+        return $body;
+    }
+
     private function _sendErrorNotification(Profile $profile, int $maxRetries, string $method, string $errorMessage): void
     {
         $recordUrl = $profile->getRecordUrl();


### PR DESCRIPTION
Adds handleFeedMeRequest() to ApiService which wraps handleRequestedUrl() and injects a nextUrl field into response.dataInfo when more pages exist. The next URL is derived from the original feed URL with _offset incremented. Updates _setUpFeedMe() to use the new dedicated method.