### PR TITLE
Fix: use FileMaker's 1-based offset default in pagination

### DIFF
--- a/src/services/ApiService.php
+++ b/src/services/ApiService.php
@@ -218,7 +218,7 @@ class ApiService extends Component
             $parsed = parse_url($url);
             parse_str($parsed['query'] ?? '', $queryParams);
 
-            $offset     = (int)($queryParams['_offset'] ?? 0);
+            $offset     = (int)($queryParams['_offset'] ?? 1);
             $nextOffset = $offset + (int)$dataInfo['returnedCount'];
 
             if ($nextOffset < (int)$dataInfo['foundCount']) {


### PR DESCRIPTION
FileMaker _offset starts at 1, not 0. Fix the default fallback so the nextUrl offset calculation is correct when _offset is not in the URL.