### PR TITLE
(FIX) Use profile.getUrl() as base URL in URL Builder playground

### DIFF
--- a/src/templates/profiles/_edit.twig
+++ b/src/templates/profiles/_edit.twig
@@ -205,9 +205,11 @@
         return parsed;
     }
 
+    var endpointBase = '{{ profile.getUrl()|split('?')[0]|e('js') }}';
+
     function buildUrl() {
         var handle     = getHandle();
-        var base       = window.location.origin + '/actions/filemaker-proxy/api/middleware';
+        var base       = endpointBase;
         var baseParams = {};
 
         if (handle) baseParams['profile'] = handle;


### PR DESCRIPTION
* Replaced window.location.origin with server-provided localhost base URL from profile.getUrl()
* Strips query string from getUrl() result to use only the endpoint path as the base