### PR TITLE
Add getBaseUrl() to Profile and display it on edit page

### DIFF
--- a/src/models/Profile.php
+++ b/src/models/Profile.php
@@ -34,20 +34,22 @@ class Profile extends Model
         return UrlHelper::cpUrl('filemaker-proxy/profiles/' . $this->id);
     }
 
-    public function getRecordUrl(): string
+    public function getBaseUrl(): string
     {
         $connection = $this->getConnection();
         $host = App::parseEnv($connection->host);
         $database = App::parseEnv($connection->database);
-        return "https://$host/fmi/data/vLatest/databases/$database/layouts/$this->layout/records";
+        return "https://$host/fmi/data/vLatest/databases/$database/layouts/$this->layout";
+    }
+
+    public function getRecordUrl(): string
+    {
+        return $this->getBaseUrl() . '/records';
     }
 
     public function getFindUrl(): string
     {
-        $connection = $this->getConnection();
-        $host = App::parseEnv($connection->host);
-        $database = App::parseEnv($connection->database);
-        return "https://$host/fmi/data/vLatest/databases/$database/layouts/$this->layout/_find";
+        return $this->getBaseUrl() . '/_find';
     }
 
     public function getConnection(): ?Connection

--- a/src/templates/profiles/_edit.twig
+++ b/src/templates/profiles/_edit.twig
@@ -67,6 +67,20 @@
         disabled: readOnly
     }) }}
 
+    {% if profile.id %}
+    <div class="field">
+        <div class="heading">
+            <label>{{ "FileMaker Base URL"|t }}</label>
+            <div class="instructions">
+                <p>{{ "The FileMaker Data API base URL for this profile's layout. Record and Find endpoints are built from this."|t }}</p>
+            </div>
+        </div>
+        <div class="input">
+            <input type="text" class="text fullwidth code" readonly value="{{ profile.getBaseUrl() }}">
+        </div>
+    </div>
+    {% endif %}
+
     <hr>
 
     <h2>{{ "URL Builder"|t }}</h2>


### PR DESCRIPTION
## Summary
- Extracted the common FileMaker Data API URL prefix into a new `getBaseUrl()` method on `Profile`, and refactored `getRecordUrl()` and `getFindUrl()` to call it with their respective segments (`/records`, `/_find`)
- Added a read-only **FileMaker Base URL** field to the profile edit page, rendered only when the profile has already been saved (i.e. `profile.id` exists)

## Test plan
- [ ] Edit an existing profile — confirm the "FileMaker Base URL" field appears with the correct URL
- [ ] Create a new profile — confirm the field does NOT appear before saving
- [ ] Verify `getRecordUrl()` still returns `<baseUrl>/records`
- [ ] Verify `getFindUrl()` still returns `<baseUrl>/_find`

🤖 Generated with [Claude Code](https://claude.com/claude-code)